### PR TITLE
Update openapi.yaml

### DIFF
--- a/yaml-unresolved/openapi.yaml
+++ b/yaml-unresolved/openapi.yaml
@@ -2681,6 +2681,7 @@ paths:
         required: true
         schema:
           type: string
+          description: "This value must be passed in plain base64-encoded format and must not be encrypted."
       responses:
         '200':
           description: An encrypted string


### PR DESCRIPTION
Added the following note to `nonce` property on /card/provision/carddetail

This value must be passed in plain base64-encoded format and must not be encrypted."